### PR TITLE
テスト基盤の導入とスナップショット追加

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,44 @@
+# テスト方針
+
+## 目的
+- 依存抽出とグラフ構築の回帰防止
+- 出力フォーマット変更の影響を素早く検知
+- CLI 変更時の動作確認コストを下げる
+
+## 現在のテスト
+- フレームワーク: xUnit
+- プロジェクト: `src/tests/CodeDepsJiro.Tests/CodeDepsJiro.Tests.csproj`
+
+## 実行方法
+```
+dotnet test src/tests/CodeDepsJiro.Tests/CodeDepsJiro.Tests.csproj
+```
+
+## 命名・配置ルール
+- テストクラスは `*Tests.cs`
+- テスト対象ごとにファイルを分割
+- 新規テストは `src/tests/CodeDepsJiro.Tests/` 配下に追加
+
+## テスト一覧
+| テスト名 | 種別 | 対象 | 検証内容 |
+| --- | --- | --- | --- |
+| `DependencyCollectorTests` | 単体/結合の中間 | `SemanticAnalyzer`, `DependencyCollector` | 依存種別（継承/実装/フィールド/プロパティ/引数/戻り値/new）の抽出 |
+| `GraphBuilderTests` | 単体 | `GraphBuilder` | ノード重複排除 |
+| `OutputSnapshotTests` | 結合/システム寄り | `SyntaxAnalyzer`〜`Exporter` | JSON/CSV 出力のスナップショット一致 |
+
+## テスト内容の詳細
+- `DependencyCollectorTests`（単体/結合の中間）: 単一ファイルに定義した `Target` が `Base`/`IService`/`Dependency`/`Other` に依存することを確認  
+  - Roslyn の `SemanticAnalyzer` と `DependencyCollector` を組み合わせているため、純粋な単体ではなく「軽い結合テスト」に近い
+- `GraphBuilderTests`（単体）: 同一 `Id` のノードが複数エッジに出ても `Nodes` が重複しないことを確認
+- `OutputSnapshotTests`（結合/システム寄り）: `dependencies.json` と `dependencies.csv` に対して出力が一致することを確認  
+  - `SyntaxAnalyzer` → `SemanticAnalyzer` → `DependencyCollector` → `GraphBuilder` → `Exporter` の一連を通すため、結合〜システム寄りの検証
+
+
+
+## 作成検討中のテスト
+| テスト名 | 種別 | 対象 | 目的 | 備考 |
+| --- | --- | --- | --- | --- |
+| `CliOptionsIntegrationTests` | 結合 | `ArgumentParser`〜`Exporter` | `--format/--output/--exclude` の組み合わせ動作 | CLI 仕様の安定化待ち |
+| `ProjectLoaderCsprojTests` | 単体/結合の中間 | `ProjectLoader` | `Compile Include/Remove` と `ProjectReference` の解決 | ケース設計が未着手 |
+| `RuleEvaluatorTests` | 単体 | `RuleEvaluator` | レイヤールール一致/不一致の検証 | ルールファイルのパースが未実装 |
+| `SemanticAnalyzerReferenceTests` | 単体/結合の中間 | `SemanticAnalyzer` | 参照解決が必要な型の解析可否 | 参照解決の対象範囲が未定 |

--- a/src/CodeDepsJiro.slnx
+++ b/src/CodeDepsJiro.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="CodeDepsJiro/CodeDepsJiro.csproj" />
+  <Project Path="tests/CodeDepsJiro.Tests/CodeDepsJiro.Tests.csproj" />
 </Solution>

--- a/src/tests/CodeDepsJiro.Tests/CodeDepsJiro.Tests.csproj
+++ b/src/tests/CodeDepsJiro.Tests/CodeDepsJiro.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CodeDepsJiro\CodeDepsJiro.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Snapshots\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Snapshots\*.csv" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/CodeDepsJiro.Tests/DependencyCollectorTests.cs
+++ b/src/tests/CodeDepsJiro.Tests/DependencyCollectorTests.cs
@@ -1,0 +1,86 @@
+using CodeDepsJiro.Models;
+using DependencyCollectorType = CodeDepsJiro.DependencyCollector.DependencyCollector;
+using SemanticAnalyzerType = CodeDepsJiro.SemanticAnalyzer.SemanticAnalyzer;
+using SyntaxAnalyzerType = CodeDepsJiro.SyntaxAnalyzer.SyntaxAnalyzer;
+
+namespace CodeDepsJiro.Tests;
+
+public sealed class DependencyCollectorTests
+{
+    [Fact]
+    public void Collect_IncludesExpectedRelations()
+    {
+        var code = """
+namespace Sample;
+
+public interface IService {}
+public class Base {}
+public class Dependency {}
+public class Other {}
+
+public class Target : Base, IService
+{
+    private Dependency _field;
+    public Dependency Prop { get; }
+
+    public Other Method(Dependency arg)
+    {
+        var local = new Dependency();
+        return new Other();
+    }
+}
+""";
+
+        var filePath = WriteTestFile(code);
+
+        try
+        {
+            var syntaxAnalyzer = new SyntaxAnalyzerType();
+            var semanticAnalyzer = new SemanticAnalyzerType();
+            var collector = new DependencyCollectorType();
+
+            var syntaxResult = syntaxAnalyzer.Analyze([filePath]);
+            var semanticResult = semanticAnalyzer.Analyze(syntaxResult);
+
+            var edges = collector.Collect(semanticResult);
+
+            AssertEdge(edges, "Target", "Base", RelationType.Inherits);
+            AssertEdge(edges, "Target", "IService", RelationType.Implements);
+            AssertEdge(edges, "Target", "Dependency", RelationType.Field);
+            AssertEdge(edges, "Target", "Dependency", RelationType.Property);
+            AssertEdge(edges, "Target", "Dependency", RelationType.Parameter);
+            AssertEdge(edges, "Target", "Other", RelationType.Return);
+            AssertEdge(edges, "Target", "Dependency", RelationType.New);
+            AssertEdge(edges, "Target", "Other", RelationType.New);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    private static void AssertEdge(
+        IReadOnlyList<DependencyEdge> edges,
+        string from,
+        string to,
+        RelationType relation)
+    {
+        Assert.Contains(edges, edge =>
+            edge.From.Name == from
+            && edge.To.Name == to
+            && edge.RelationType == relation);
+    }
+
+    private static string WriteTestFile(string code)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "TestData");
+        Directory.CreateDirectory(directory);
+
+        var filePath = Path.Combine(directory, $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(filePath, code);
+        return filePath;
+    }
+}

--- a/src/tests/CodeDepsJiro.Tests/GraphBuilderTests.cs
+++ b/src/tests/CodeDepsJiro.Tests/GraphBuilderTests.cs
@@ -1,0 +1,49 @@
+using CodeDepsJiro.Models;
+using GraphBuilderType = CodeDepsJiro.GraphBuilder.GraphBuilder;
+
+namespace CodeDepsJiro.Tests;
+
+public sealed class GraphBuilderTests
+{
+    [Fact]
+    public void Build_DeduplicatesNodesById()
+    {
+        var from = new Node
+        {
+            Id = "A",
+            Name = "A",
+            Namespace = "Sample",
+            Kind = NodeKind.Class,
+        };
+
+        var to = new Node
+        {
+            Id = "B",
+            Name = "B",
+            Namespace = "Sample",
+            Kind = NodeKind.Class,
+        };
+
+        var edges = new List<DependencyEdge>
+        {
+            new()
+            {
+                From = from,
+                To = to,
+                RelationType = RelationType.Field,
+            },
+            new()
+            {
+                From = from,
+                To = to,
+                RelationType = RelationType.Property,
+            },
+        };
+
+        var builder = new GraphBuilderType();
+        var graph = builder.Build(edges);
+
+        Assert.Equal(2, graph.Nodes.Count);
+        Assert.Equal(2, graph.Edges.Count);
+    }
+}

--- a/src/tests/CodeDepsJiro.Tests/OutputSnapshotTests.cs
+++ b/src/tests/CodeDepsJiro.Tests/OutputSnapshotTests.cs
@@ -1,0 +1,122 @@
+using CodeDepsJiro.Exporter;
+using CodeDepsJiro.Models;
+using DependencyCollectorType = CodeDepsJiro.DependencyCollector.DependencyCollector;
+using GraphBuilderType = CodeDepsJiro.GraphBuilder.GraphBuilder;
+using SemanticAnalyzerType = CodeDepsJiro.SemanticAnalyzer.SemanticAnalyzer;
+using SyntaxAnalyzerType = CodeDepsJiro.SyntaxAnalyzer.SyntaxAnalyzer;
+
+namespace CodeDepsJiro.Tests;
+
+public sealed class OutputSnapshotTests
+{
+    [Fact]
+    public void JsonOutput_MatchesSnapshot()
+    {
+        var filePath = WriteTestFile(GetSampleCode());
+
+        try
+        {
+            var output = GenerateOutput(filePath, new JsonExporter());
+            var normalized = NormalizeNewlines(output);
+            var expected = NormalizeNewlines(ReadSnapshot("dependencies.json"));
+
+            Assert.Equal(expected, normalized);
+        }
+        finally
+        {
+            DeleteTestFile(filePath);
+        }
+    }
+
+    [Fact]
+    public void CsvOutput_MatchesSnapshot()
+    {
+        var filePath = WriteTestFile(GetSampleCode());
+
+        try
+        {
+            var output = GenerateOutput(filePath, new CsvExporter());
+            var normalized = NormalizeNewlines(output);
+            var expected = NormalizeNewlines(ReadSnapshot("dependencies.csv"));
+
+            Assert.Equal(expected, normalized);
+        }
+        finally
+        {
+            DeleteTestFile(filePath);
+        }
+    }
+
+    private static string GenerateOutput(string filePath, IExporter exporter)
+    {
+        var syntaxAnalyzer = new SyntaxAnalyzerType();
+        var semanticAnalyzer = new SemanticAnalyzerType();
+        var collector = new DependencyCollectorType();
+        var graphBuilder = new GraphBuilderType();
+
+        var syntaxResult = syntaxAnalyzer.Analyze([filePath]);
+        var semanticResult = semanticAnalyzer.Analyze(syntaxResult);
+        var edges = collector.Collect(semanticResult);
+        var graph = graphBuilder.Build(edges);
+
+        return exporter.Export(graph, new List<RuleViolation>());
+    }
+
+    private static string GetSampleCode()
+    {
+        return """
+namespace Sample;
+
+public class Dependency {}
+
+public class Target
+{
+    private Dependency _field;
+    public Dependency Prop { get; }
+
+    public Dependency Method(Dependency arg)
+    {
+        var local = new Dependency();
+        return arg;
+    }
+}
+""";
+    }
+
+    private static string ReadSnapshot(string fileName)
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        var snapshotsDirectory = Path.Combine(baseDirectory, "Snapshots");
+        var snapshotPath = Path.Combine(snapshotsDirectory, fileName);
+
+        if (!File.Exists(snapshotPath))
+        {
+            throw new FileNotFoundException($"Snapshot not found: {snapshotPath}");
+        }
+
+        return File.ReadAllText(snapshotPath);
+    }
+
+    private static string WriteTestFile(string code)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "TestData");
+        Directory.CreateDirectory(directory);
+
+        var filePath = Path.Combine(directory, $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(filePath, code);
+        return filePath;
+    }
+
+    private static void DeleteTestFile(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    private static string NormalizeNewlines(string value)
+    {
+        return value.Replace("\r\n", "\n").TrimEnd('\n');
+    }
+}

--- a/src/tests/CodeDepsJiro.Tests/Snapshots/dependencies.csv
+++ b/src/tests/CodeDepsJiro.Tests/Snapshots/dependencies.csv
@@ -1,0 +1,6 @@
+From,To,RelationType
+Target,Dependency,Field
+Target,Dependency,Property
+Target,Dependency,Return
+Target,Dependency,Parameter
+Target,Dependency,New

--- a/src/tests/CodeDepsJiro.Tests/Snapshots/dependencies.json
+++ b/src/tests/CodeDepsJiro.Tests/Snapshots/dependencies.json
@@ -1,0 +1,40 @@
+{
+  "nodes": [
+    {
+      "name": "Target",
+      "kind": "Class"
+    },
+    {
+      "name": "Dependency",
+      "kind": "Class"
+    }
+  ],
+  "edges": [
+    {
+      "from": "Target",
+      "to": "Dependency",
+      "relationType": "Field"
+    },
+    {
+      "from": "Target",
+      "to": "Dependency",
+      "relationType": "Property"
+    },
+    {
+      "from": "Target",
+      "to": "Dependency",
+      "relationType": "Return"
+    },
+    {
+      "from": "Target",
+      "to": "Dependency",
+      "relationType": "Parameter"
+    },
+    {
+      "from": "Target",
+      "to": "Dependency",
+      "relationType": "New"
+    }
+  ],
+  "violations": []
+}


### PR DESCRIPTION
## 概要
- xUnit テストプロジェクトを追加
- DependencyCollector / GraphBuilder の最小テストを実装
- JSON/CSV 出力のスナップショットテストを追加
- テスト方針ドキュメント（docs/testing.md）を拡充